### PR TITLE
frontend: fix ws handling in instruqt proxy env

### DIFF
--- a/vectordb-genai-101/chat-app-code/frontend/next.config.mjs
+++ b/vectordb-genai-101/chat-app-code/frontend/next.config.mjs
@@ -9,8 +9,12 @@ export default {
     return [
       {
         source: '/api/:path*',
-        destination: 'http://localhost:8000/:path*', // Proxy to FastAPI backend
+        destination: 'http://localhost:8000/:path*', // Proxy to FastAPI backend (rest)
       },
+      {
+        source: '/ws',
+        destination: 'http://localhost:8000/ws', // Proxy to FastAPI backend (ws)
+      }
     ];
   },
   webpack: (config, { isServer }) => {

--- a/vectordb-genai-101/chat-app-code/frontend/src/components/main_chat.tsx
+++ b/vectordb-genai-101/chat-app-code/frontend/src/components/main_chat.tsx
@@ -16,7 +16,7 @@ export default function MainChat() {
     // Define the connectWebSocket function to handle WebSocket connections
     const connectWebSocket = () => {
         const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
-        const websocketURL = `${protocol}${window.location.hostname}:8000/ws`;
+        const websocketURL = `/ws`;
         websocket.current = new WebSocket(websocketURL);
 
         websocket.current.onopen = () => {


### PR DESCRIPTION
Instruqt proxies requests to your sandbox (without your involvement). 

In this app, the frontend (browser-side) makes REST API calls to the python backend, proxied through the node.js server (/api) via next.js reverse proxy ("rewrite"). However, the websocket connection code (executed by the browser) was just trying to make direct calls to the python backend (on port 8000), which breaks how Instruqt proxies HTTP to the sandbox. So we add another reverse proxy statement ("rewrite") to next router (running in node.js server) to reverse proxy /ws to the python backend, and we tell the browser to connect WS via the node.js server (/ws), the same as REST APIs. This keeps all traffic from browser to sandbox on 1 port which allows Instruqt proxy to work as expected.

The previous code was trying to trivially stick ":8000" to the end of the current browser URL hostname, which would work in scenarios where port 8000 is actually exposed on that browser hostname, but for Instruqt, this fails, because the URL that instruqt presents is actually something like `13424332.instruqt.com/3000/` where `13424332.instruqt.com` is the Instruqt proxy and `/3000` is the destination port. So the browser was trying to connect WS to `13424332.instruqt.com:8000` which isn't exposed. only `13424332.instruqt.com:80` is exposed.

You could also just change the ws code to connect to `/api/ws`, which I think should work with the existing REST rewrite. The change proposed here is more explicit for ws.